### PR TITLE
add nav link and convert anchor tags to navLink in layout.jsx

### DIFF
--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, NavLink } from 'react-router-dom';
 
 import './Layout.css';
 
@@ -21,15 +21,15 @@ export function Layout() {
 					<Outlet />
 				</main>
 				<nav className="Nav">
-					<a href="#" className="Nav-link">
+					<NavLink to="/" className="Nav-link">
 						Home
-					</a>
-					<a href="#" className="Nav-link">
+					</NavLink>
+					<NavLink to="/list" className="Nav-link">
 						List
-					</a>
-					<a href="#" className="Nav-link">
+					</NavLink>
+					<NavLink to="/add-item" className="Nav-link">
 						Add Item
-					</a>
+					</NavLink>
 				</nav>
 			</div>
 		</>


### PR DESCRIPTION
## Description
Imported NavLink from React-Router-Dom and converted anchor tags in Layout.jsx to NavLinks. Users can navigate between pages correctly and the 'active' class is applied to the NavLink that is active properly. 

## Related Issue
closes 2

## Acceptance Criteria
- [x] The `nav` element is added to the `Layout` component
- [x] Links to the "Home", "List", and "Add item" pages of the app are In the `nav` element
- [x] The links all function as expected using  the `NavLink` component from `react-router-dom`

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
| ✓   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
n/a

### After
n/a

## Testing Steps / QA Criteria
- pull down branch ad-af-update-nav-links
- npm start
- in browser window test links in bottom nav bar to confirm they redirect to the correct pages and the currently active page has styling updates
