### PR TITLE
worked together to conditionally render filter and added add item but…

### DIFF
--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { ListItem } from '../components';
-
+import { Link } from 'react-router-dom';
 
 export function List({ data, listToken }) {
 	const [listFilter, setListFilter] = useState('');
@@ -16,28 +16,30 @@ export function List({ data, listToken }) {
 
 	return (
 		<>
-      <h2>Smart Shopping List</h2>
+			<h2>Smart Shopping List</h2>
 			{listToken && (
 				<p>Want to share your list? Your list token is: {listToken}</p>
 			)}
-			<form onSubmit={submitHandler}>
-				<label htmlFor="itemInput">Filter Items: </label>
-				<input
-					type="text"
-					id="itemInput"
-					name="itemInput"
-					placeholder="Start typing here..."
-					value={listFilter}
-					onChange={(event) => setListFilter(event.target.value)}
-				/>
-				{listFilter && (
-					<span>
-						<button type="reset" onClick={clickHandler}>
-							X
-						</button>
-					</span>
-				)}
-			</form>
+			{data.length > 0 ? (
+				<form onSubmit={submitHandler}>
+					<label htmlFor="itemInput">Filter Items: </label>
+					<input
+						type="text"
+						id="itemInput"
+						name="itemInput"
+						placeholder="Start typing here..."
+						value={listFilter}
+						onChange={(event) => setListFilter(event.target.value)}
+					/>
+					{listFilter && (
+						<span>
+							<button type="reset" onClick={clickHandler}>
+								X
+							</button>
+						</span>
+					)}
+				</form>
+			) : null}
 			{data.length > 0 ? (
 				<ul>
 					{data
@@ -49,7 +51,12 @@ export function List({ data, listToken }) {
 						})}
 				</ul>
 			) : (
-				<p>There are currently no items in the list.</p>
+				<div>
+					<p>There are currently no items in the list.</p>
+					<Link to={'/add-item'}>
+						<button>Add item</button>
+					</Link>
+				</div>
 			)}
 		</>
 	);


### PR DESCRIPTION

_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

With these changes we first had to conditionally render the filter so that it is not viewable to the user if their list is empty.
 Instead of a user with an empty list seeing the filter, they now see the message that there are currently no items in the list and a button with the ability to take them to the add item page. 
We used the React "Link to" from the react-router-dom to navigate the user between pages. 


## Related Issue


closes #7 
## Acceptance Criteria

The list view, when there are no items to display, should show a prompt (e.g., a button) for the user to add their first item

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|   ✓  | :bug: Bug fix              |
| ✓  | :sparkles: New feature     |
|   ✓ | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before


<img width="462" alt="Screenshot 2023-01-31 224959" src="https://user-images.githubusercontent.com/98853049/215941205-8f4c684b-5735-4f42-b8c0-c360673d9320.png">




### After


<img width="431" alt="Screenshot 2023-01-31 224808" src="https://user-images.githubusercontent.com/98853049/215940605-99e0bcaa-f258-4ba0-bb22-a8c0c4d6bf25.png">
## Testing Steps / QA Criteria

-Click on the create new list option on the home page.
-Once you are directed to the list page, you should no longer see the item filter input, but now you will see a button that prompts the user to add a new item. 
-Click the button and it will direct you to the add new item page where you can add an item. 
-Verify that your item was added by returning to the list page. 