### PR TITLE
As af calculate next purchase date

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -7,7 +7,7 @@ import {
 	updateDoc,
 } from 'firebase/firestore';
 import { db } from './config';
-import { getFutureDate } from '../utils';
+import { getFutureDate, getDaysBetweenDates } from '../utils';
 
 /**
  * Return whether a collection has documents in it (list token exists) or is empty (list token does not exist)

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -132,13 +132,13 @@ export async function updateItem(
 		dateLastPurchased === null
 			? getDaysBetweenDates(today, dateCreated.toDate())
 			: getDaysBetweenDates(today, dateLastPurchased.toDate());
-	const newTotalPurcahses = totalPurchases + 1;
+	const newTotalPurchases = totalPurchases + 1;
 
 	// calculate the estimated days until item should be purchased again
 	const daysUntilNextPurchase = calculateEstimate(
 		lastEstimatedInterval,
 		daysSinceLastTransaction,
-		newTotalPurcahses,
+		newTotalPurchases,
 	);
 
 	// get reference to the item's document in Firestore
@@ -146,7 +146,7 @@ export async function updateItem(
 	// set dateLastPurchased to current date, incrememt totalPurchases
 	await updateDoc(itemDocRef, {
 		dateLastPurchased: today,
-		totalPurchases: newTotalPurcahses,
+		totalPurchases: newTotalPurchases,
 		dateNextPurchased: getFutureDate(daysUntilNextPurchase),
 	});
 }

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -104,18 +104,18 @@ export async function addItem(
 	}
 }
 
-export async function updateItem(listToken, itemId, totalPurchases) {
+export async function updateItem(listToken, itemData) {
 	/**
 	 * TODO: Fill this out so that it uses the correct Firestore function
 	 * to update an existing item. You'll need to figure out what arguments
 	 * this function must accept!
 	 */
 	// get reference to the item's document in Firestore
-	const itemDocRef = doc(db, listToken, itemId);
+	const itemDocRef = doc(db, listToken, itemData.id);
 	// set dateLastPurchased to current date, incrememt totalPurchases
 	await updateDoc(itemDocRef, {
 		dateLastPurchased: new Date(),
-		totalPurchases: totalPurchases + 1,
+		totalPurchases: itemData.totalPurchases + 1,
 	});
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -8,6 +8,7 @@ import {
 } from 'firebase/firestore';
 import { db } from './config';
 import { getFutureDate, getDaysBetweenDates } from '../utils';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 /**
  * Return whether a collection has documents in it (list token exists) or is empty (list token does not exist)
@@ -104,18 +105,49 @@ export async function addItem(
 	}
 }
 
-export async function updateItem(listToken, itemData) {
+/**
+ * @param {String} listToken the list token that corresponds to a Firebase collection
+ * @param {Object} itemData the object containing all of the current data for this item from our app's state (destructured in implementation)
+ */
+export async function updateItem(
+	listToken,
+	{ id, dateLastPurchased, dateNextPurchased, dateCreated, totalPurchases },
+) {
 	/**
 	 * TODO: Fill this out so that it uses the correct Firestore function
 	 * to update an existing item. You'll need to figure out what arguments
 	 * this function must accept!
 	 */
+
+	// get current date, the last estimated interval, days since last transaction, and increment total purchases
+	const today = new Date();
+	const lastEstimatedInterval =
+		dateLastPurchased === null
+			? getDaysBetweenDates(dateNextPurchased.toDate(), dateCreated.toDate())
+			: getDaysBetweenDates(
+					dateNextPurchased.toDate(),
+					dateLastPurchased.toDate(),
+			  );
+	const daysSinceLastTransaction =
+		dateLastPurchased === null
+			? getDaysBetweenDates(today, dateCreated.toDate())
+			: getDaysBetweenDates(today, dateLastPurchased.toDate());
+	const newTotalPurcahses = totalPurchases + 1;
+
+	// calculate the estimated days until item should be purchased again
+	const daysUntilNextPurchase = calculateEstimate(
+		lastEstimatedInterval,
+		daysSinceLastTransaction,
+		newTotalPurcahses,
+	);
+
 	// get reference to the item's document in Firestore
-	const itemDocRef = doc(db, listToken, itemData.id);
+	const itemDocRef = doc(db, listToken, id);
 	// set dateLastPurchased to current date, incrememt totalPurchases
 	await updateDoc(itemDocRef, {
-		dateLastPurchased: new Date(),
-		totalPurchases: itemData.totalPurchases + 1,
+		dateLastPurchased: today,
+		totalPurchases: newTotalPurcahses,
+		dateNextPurchased: getFutureDate(daysUntilNextPurchase),
 	});
 }
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -4,10 +4,9 @@ import './ListItem.css';
 
 export function ListItem({ itemData, listToken }) {
 	const onChangeHandler = () => {
-		// send listToken (collection), id (document), and value (totalPurchases) to database api
+		// send listToken (collection) and all current item data to database api
 		if (!withinTwentyFourHours(itemData.dateLastPurchased)) {
 			updateItem(listToken, itemData);
-			// updateItem(listToken, event.target.id, Number(event.target.value));
 		}
 	};
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -3,10 +3,11 @@ import { withinTwentyFourHours } from '../utils';
 import './ListItem.css';
 
 export function ListItem({ itemData, listToken }) {
-	const onChangeHandler = (event) => {
+	const onChangeHandler = () => {
 		// send listToken (collection), id (document), and value (totalPurchases) to database api
 		if (!withinTwentyFourHours(itemData.dateLastPurchased)) {
-			updateItem(listToken, event.target.id, Number(event.target.value));
+			updateItem(listToken, itemData);
+			// updateItem(listToken, event.target.id, Number(event.target.value));
 		}
 	};
 
@@ -15,7 +16,6 @@ export function ListItem({ itemData, listToken }) {
 			<input
 				type="checkbox"
 				id={itemData.id}
-				value={itemData.totalPurchases}
 				onChange={onChangeHandler}
 				checked={withinTwentyFourHours(itemData.dateLastPurchased)}
 			/>

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -24,9 +24,14 @@ export function withinTwentyFourHours(dateLastPurchased) {
 	return today - prevDate < ONE_DAY_IN_MILLISECONDS;
 }
 
+/**
+ * @param {Date} newerPurchase a JavaScript Date
+ * @param {Date} olderPurchase a JavaScript Date
+ * @returns {number} the whole number of days between the two input dates
+ */
 export function getDaysBetweenDates(newerPurchase, olderPurchase) {
-	const newerPurchaseMilliseconds = newerPurchase.toDate().getTime();
-	const olderPurchaseMilliseconds = olderPurchase.toDate().getTime();
+	const newerPurchaseMilliseconds = newerPurchase.getTime();
+	const olderPurchaseMilliseconds = olderPurchase.getTime();
 
 	const timeBetween = newerPurchaseMilliseconds - olderPurchaseMilliseconds;
 	const daysBetween = Math.floor(timeBetween / ONE_DAY_IN_MILLISECONDS);

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -23,3 +23,13 @@ export function withinTwentyFourHours(dateLastPurchased) {
 	const today = new Date().getTime();
 	return today - prevDate < ONE_DAY_IN_MILLISECONDS;
 }
+
+export function getDaysBetweenDates(newerPurchase, olderPurchase) {
+	const newerPurchaseMilliseconds = newerPurchase.toDate().getTime();
+	const olderPurchaseMilliseconds = olderPurchase.toDate().getTime();
+
+	const timeBetween = newerPurchaseMilliseconds - olderPurchaseMilliseconds;
+	const daysBetween = Math.floor(timeBetween / ONE_DAY_IN_MILLISECONDS);
+
+	return daysBetween;
+}


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

##Description 
For this issue, we refactored the Firebase update item function so that it calculates the next estimated date that the user needs to purchase the item and stores it in the database as the new value for date next purchased. 
Then we refactored ListItem.jsx so that now it changes all of the items data in updateItem instead of partial data. 
In utils/dates.js we added a function called getDaysBetweenDates that will calculate the number of days between two purchase dates. 
I learned a lot about how documents in collections in Firestore can be tested by editing the date values. That was awesome of Aubrey to show me! -Amy

## Related Issue
closes #10 


## Acceptance Criteria
- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number
- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before


### After



## Testing Steps / QA Criteria

- pull down the branch and run `npm start` to view the page at http://localhost:3000/
- make sure you have joined an existing list and that the list has items
- click on an item (name or checkbox) and the checkbox should become checked
- view the updated dateLastPurchased, dateNextPurchased, and totalPurchases values for the corresponding item in the [Firestore dashboard](https://console.firebase.google.com/u/2/project/tcl-51-smart-shopping-list/firestore/data/~2F)
- To test dateNextPurchased estimates changing over time, manipulate the date fields in the Firestore document. Click to purchase the item again. (Ensure that the dateLastPurchased is at least 24 hours ago in order to enable the checkbox to purchase. )