### PR TITLE
Auto-uncheck items/auto-re-sort list when time runs out

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -6,6 +6,9 @@ import {
 	deleteDoc,
 	getCountFromServer,
 	updateDoc,
+	query,
+	where,
+	getDocs,
 } from 'firebase/firestore';
 import { db } from './config';
 import { getFutureDate, getDaysBetweenDates } from '../utils';
@@ -206,4 +209,24 @@ export async function deleteItem(listToken, id) {
 	 */
 
 	await deleteDoc(doc(db, listToken, id));
+}
+
+/**
+ * @param {String} listToken the list token that corresponds to a Firebase collection
+ * Finds the hidden item in the database and updates it's date next purchsed to 1 day in the future to trigger a data refresh
+ */
+export async function refreshData(listToken) {
+	const q = query(collection(db, listToken), where('hidden', '==', true));
+	const querySnapshot = await getDocs(q);
+
+	let hiddenId;
+	querySnapshot.forEach((doc) => {
+		hiddenId = doc.id;
+	});
+
+	const hiddenDocRef = doc(db, listToken, hiddenId);
+
+	await updateDoc(hiddenDocRef, {
+		dateNextPurchased: getFutureDate(1),
+	});
 }

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { ListItem } from '../components';
 import { Link } from 'react-router-dom';
+import { useEffect } from 'react';
+import { refreshData } from '../api';
 
 export function List({ data, listToken }) {
 	const [listFilter, setListFilter] = useState('');
@@ -13,6 +15,18 @@ export function List({ data, listToken }) {
 	const submitHandler = (event) => {
 		event.preventDefault();
 	};
+
+	const ONE_DAY_IN_MILLISECONDS = 86400000;
+
+	// force refresh of list to re-sort/clear checkboxes once a day
+	useEffect(() => {
+		const refreshTimeout = setTimeout(() => {
+			refreshData(listToken);
+		}, ONE_DAY_IN_MILLISECONDS);
+		return () => {
+			clearTimeout(refreshTimeout);
+		};
+	}, [listToken, data]);
 
 	return (
 		<>


### PR DESCRIPTION
## Description

Added a trigger to update the list sorting and auto-uncheck the purchased check boxes once a day if the user remains on the list view page with no changes. Did this by triggering an update on the hidden item in the list, which in turn triggers Firebase to stream new data to our app. 

What we learned:
- Any change to the database will stream new data to our app, and will in turn cause the list view to re-render, which recalculates the timings for all check-boxes and status labels
- We learned how to query for data in Firebase, and how to read data from the returned object. Firebase will always return an iterable object, even if there is only one result, and you must iterate over this object to access the individual document data.

## Related Issue
Closes #29 

## Acceptance Criteria
- [x] If a user stays idle on the List View for >24 hours any checked items should become un-checked
- [x] If a user stays idle on the List View for >24 hours the status labels for items should update to their new values

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
| ✓   | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Testing Steps / QA Criteria
- pull down the branch and run `npm start` to view the page at http://localhost:3000/
- make sure you have joined an existing list and that the list has items
- add a console log in views/List.jsx and change the timeout value on line 25 to something shorter in order to see the refreshing functionality trigger
- in the Firestore dashboard check the dateNextPurchased value of the hidden item and see that it updates when the refresh triggers
- Refresh should also trigger in the set amount of time after an item is updated (checked, deleted, etc)
- Adjust the dateLastPurchased and dateNextPurchased values in the Firestore dashboard in order to view checkbox/status changes when the refresh triggers
