### PR TITLE
conditionally show navigations links based on listToken presense

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,7 +58,7 @@ export function App() {
 	return (
 		<Router>
 			<Routes>
-				<Route path="/" element={<Layout />}>
+				<Route path="/" element={<Layout listToken={listToken} />}>
 					{listToken ? (
 						<Route index element={<Navigate to="/list" />} />
 					) : (

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -10,7 +10,7 @@ import './Layout.css';
  * defined in `App.jsx`.
  */
 
-export function Layout() {
+export function Layout({ listToken }) {
 	return (
 		<>
 			<div className="Layout">
@@ -21,15 +21,21 @@ export function Layout() {
 					<Outlet />
 				</main>
 				<nav className="Nav">
-					<NavLink to="/" className="Nav-link">
-						Home
-					</NavLink>
-					<NavLink to="/list" className="Nav-link">
-						List
-					</NavLink>
-					<NavLink to="/add-item" className="Nav-link">
-						Add Item
-					</NavLink>
+					{!listToken ? (
+						<NavLink to="/" className="Nav-link">
+							Home
+						</NavLink>
+					) : null}
+					{listToken ? (
+						<NavLink to="/list" className="Nav-link">
+							List
+						</NavLink>
+					) : null}
+					{listToken ? (
+						<NavLink to="/add-item" className="Nav-link">
+							Add Item
+						</NavLink>
+					) : null}
 				</nav>
 			</div>
 		</>


### PR DESCRIPTION
## Description

When there is no list token present the user will only be able to access the Home page. Once there is a list token, the Home page is disabled and the user now has access to the List and Add Item pages. 

## Related Issue

closes #26

## Acceptance Criteria

Does the thing (listed above).

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|   ✓ | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
![Screen Shot 2023-02-23 at 10 32 12 PM](https://user-images.githubusercontent.com/70449557/221085424-0aed217e-18b0-47a4-9549-58c9da5fb57c.png)

![Screen Shot 2023-02-23 at 10 31 59 PM](https://user-images.githubusercontent.com/70449557/221085437-7ba50f76-2575-46da-8f86-2cf5ef4303b0.png)

### After
<img width="961" alt="after1" src="https://user-images.githubusercontent.com/70449557/221085509-97911610-92b8-4fb4-832b-db2a01c0ef5a.PNG">

<img width="961" alt="after2" src="https://user-images.githubusercontent.com/70449557/221085565-fe78756c-ef96-47ee-b90d-3806b332cb97.PNG">

## Testing Steps / QA Criteria

If there is a token present, delete it from storage in the browser. Refresh the browser and go back to the home page. The List and Add Item buttons should not be present. Once you obtain a token, you should be redirected to the List page as usual, but now the Home button will not be present and the List and Add Item buttons will be available. 
