### PR TITLE
Style Unpopulated List View

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,7 @@
 @tailwind utilities;
 
 @layer components {
+	/* App Common Styling */
 	html,
 	body,
 	#root,
@@ -14,7 +15,16 @@
 		@apply w-full flex justify-center lg:text-lg bg-cream text-darkgray dark:bg-darkgray  dark:text-offwhite;
 	}
 
+	.ButtonGeneral {
+		@apply bg-lightgray text-offwhite py-2 px-4  hover:bg-medgray border border-lightgray rounded mt-2 mb-2;
+	}
+
+	.InputGeneral {
+		@apply text-darkgray p-1 rounded border border-lightgray w-full;
+	}
+
 	/* Layout Styling  */
+
 	.Layout {
 		@apply w-5/6 mx-auto max-w-sm flex flex-col justify-between;
 	}
@@ -40,7 +50,7 @@
 	}
 
 	/* ListItem Component Styling */
-  
+
 	.item-inactive {
 		@apply border-2 border-statusgray/70 rounded-md bg-statusgray/30;
 	}
@@ -53,22 +63,18 @@
 		@apply border-2 border-statusorange/70 rounded-md bg-statusorange/30 text-darkgray dark:text-offwhite;
 	}
 
-  .item-mid {
+	.item-mid {
 		@apply border-2 border-statusgreen/70 rounded-md bg-statusgreen/30 text-darkgray dark:text-offwhite;
 	}
 
-  .item-long {
+	.item-long {
 		@apply border-2 border-statusblue/70 rounded-md bg-statusblue/30 text-darkgray dark:text-offwhite;
 	}
-  
+
 	/* Add Item Form Styling */
-  
+
 	.ItemLabel {
 		@apply pb-3 pt-5 pr-4 block;
-	}
-
-	.AddItemInput {
-		@apply text-darkgray p-1 rounded border border-lightgray w-full;
 	}
 
 	.RadioItem {
@@ -77,10 +83,6 @@
 
 	.RadioInput {
 		@apply w-4 h-4 accent-lightgray;
-	}
-
-	.FormButton {
-		@apply bg-lightgray text-offwhite py-2 px-4  hover:bg-medgray border border-lightgray rounded mt-2 mb-2;
 	}
 }
 

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -85,10 +85,10 @@ export function List({ data, listToken }) {
 						})}
 				</ul>
 			) : (
-				<div>
-					<p>There are currently no items in the list.</p>
+				<div className="flex flex-col items-center mt-10">
+					<p className=" mb-10">There are currently no items in the list.</p>
 					<Link to={'/add-item'}>
-						<button>Add item</button>
+						<button className="ButtonGeneral">Add item</button>
 					</Link>
 				</div>
 			)}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,7 +15,7 @@ module.exports = {
 				darkgray: '#1F1F27',
 				medgray: '#403F50',
 				lightgray: '#746B7B',
-				cream: '#E8E1D0',
+				cream: '#F3F2EF',
 				offwhite: '#F1E8E8',
 				statusred: '#D9534F',
 				statusorange: '#F0AD4E',


### PR DESCRIPTION
## Description
Updated cream color in tailwind config file, changed button and input classes to general in index.css for use on multiple pages, styled the non-populated version of the list view.

## Related Issue
In relation to item 13 (partially complete)

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
| ✓   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
![list-before](https://user-images.githubusercontent.com/107282070/222617834-ee180c1d-3d9a-40e4-a5b9-427a98f8bc16.png)

### After
![list light after](https://user-images.githubusercontent.com/107282070/222617842-4fd745b7-0a92-4cde-8ac4-31ecefdc9214.png)

![list dark after](https://user-images.githubusercontent.com/107282070/222617857-c29a19ab-e77a-4033-860e-959add88a166.png)

## Testing Steps / QA Criteria
Pull down the branch. (If you haven't updated since the icon library was installed run npm install to install dependencies). Make sure you are on an empty list. Run npm start and view the new styling on the unpopulated List view at http://localhost:3000/.
